### PR TITLE
Remove error_log function

### DIFF
--- a/src/Broker.php
+++ b/src/Broker.php
@@ -199,7 +199,6 @@ class Broker
 
         if ($contentType != 'application/json') {
             $message = "Expected application/json response, got $contentType";
-            error_log($message . "\n\n" . $response);
             throw new Exception($message, $httpCode);
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -183,8 +183,6 @@ abstract class Server
         } elseif (strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) {
             $this->returnType = 'json';
         }
-        
-        error_log($this->returnType);
     }
 
     /**


### PR DESCRIPTION
Hi,

I think that writing in the log error should not be by default but only in case to debug.
In such cases, a feature can be implemented the psr/log would be desirable.

Thanks