### PR TITLE
Change verb to logout method

### DIFF
--- a/src/Broker.php
+++ b/src/Broker.php
@@ -236,7 +236,7 @@ class Broker
      */
     public function logout()
     {
-        $this->request('POST', 'logout');
+        $this->request('GET', 'logout');
     }
 
     /**


### PR DESCRIPTION
When the POST verb is used, request body is mandatory.
For the logout method, no data is transmitted.
Changing by the method GET.

Thanks