### PR TITLE
Fix issues when server restart new session

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -88,6 +88,10 @@ abstract class Server
         session_id($linkedId);
         session_start();
 
+        if (empty($_SESSION)) {
+            $this->startUserSession();
+        }
+
         $this->brokerId = $this->validateBrokerSessionId($sid);
     }
     


### PR DESCRIPTION
Hi!

The configuration parameters and default php for "Time To Live" are :
- Cookies: 3 600 sec
- PHP Session: 1 440 sec
- Cache for SSO files: 36 000 sec

If PHP sessions are renewed by the reboot of the server or by cleaning the garbage, new PHP sessions for SSO will be empty.

Brokers always have a valid cookie with the token. So they do not attach with the SSO. SSO server have a valid cache with SID. And brokers have the following fatal error: "Unknown client IP address for the attached session".

Thanks for PR.

