### PR TITLE
Update readme for broker name and secret notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ For more information, checkout the `server` example.
 When creating a Jasny\SSO\Broker instance, you need to pass the server url, broker id and broker secret. The broker id
 and secret needs to be registered at the server (so fetched when using `getBrokerInfo($brokerId)`).
 
+**Be careful**: *The broker id and broker secret cannot contain the "-" character.*
+
 Next you need to call `attach()`. This will generate a token an redirect the client to the server to attach the token
 to the client's session. If the client is already attached, the function will simply return.
 


### PR DESCRIPTION
Hi!

If exemple, the broker id is "application-one", I get a fatal error "Invalid session id" because the pattern of preg_match use "-" character delimiter.

Thanks