### PR TITLE
changed requiring path for autoload in example files

### DIFF
--- a/examples/ajax-broker/api.php
+++ b/examples/ajax-broker/api.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 $broker = new Jasny\SSO\Broker(getenv('SSO_SERVER'), getenv('SSO_BROKER_ID'), getenv('SSO_BROKER_SECRET'));
 

--- a/examples/broker/error.php
+++ b/examples/broker/error.php
@@ -1,6 +1,5 @@
 <?php
-require_once __DIR__ . '/../../vendor/autoload.php';
-
+.idea/copyright/
 $broker = new Jasny\SSO\Broker(getenv('SSO_SERVER'), getenv('SSO_BROKER_ID'), getenv('SSO_BROKER_SECRET'));
 $error = $_GET['sso_error'];
 

--- a/examples/broker/index.php
+++ b/examples/broker/index.php
@@ -2,7 +2,7 @@
 use Jasny\SSO\NotAttachedException;
 use Jasny\SSO\Exception as SsoException;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 if (isset($_GET['sso_error'])) {
     header("Location: error.php?sso_error=" . $_GET['sso_error'], true, 307);

--- a/examples/broker/login.php
+++ b/examples/broker/login.php
@@ -1,6 +1,6 @@
 <?php
 use Jasny\SSO\NotAttachedException;
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
 
 $broker = new Jasny\SSO\Broker(getenv('SSO_SERVER'), getenv('SSO_BROKER_ID'), getenv('SSO_BROKER_SECRET'));
 $broker->attach(true);

--- a/examples/server/index.php
+++ b/examples/server/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../../../vendor/autoload.php';
 require_once 'MySSOServer.php';
 
 $ssoServer = new MySSOServer();


### PR DESCRIPTION
After I downloaded the library with composer require, as per documentation, and tried to use the examples I noticed that the require_once statements were pointing to the wrong path, since they would live under /vendor/jasny/sso/examples