### PR TITLE
remove header string type

### DIFF
--- a/src/Broker/Broker.php
+++ b/src/Broker/Broker.php
@@ -314,12 +314,12 @@ class Broker
      * Handle the response of the cURL request.
      *
      * @param int    $httpCode  HTTP status code
-     * @param string $ctHeader  Content-Type header
+     * @param string|null $ctHeader  Content-Type header
      * @param string $body      Response body
      * @return mixed
      * @throws RequestException
      */
-    protected function handleResponse(int $httpCode, string $ctHeader, string $body)
+    protected function handleResponse(int $httpCode, $ctHeader, string $body)
     {
         if ($httpCode === 204) {
             return null;


### PR DESCRIPTION
when response http code 204, the header is null.

**CURLINFO_CONTENT_TYPE** - Content-Type: of the requested document. `NULL` indicates server did not send valid Content-Type: header

reference: https://www.php.net/manual/en/function.curl-getinfo.php